### PR TITLE
feat(board)[OK-59] Implement board eraser

### DIFF
--- a/frontend/.depcheckrc
+++ b/frontend/.depcheckrc
@@ -1,0 +1,2 @@
+ignores: ["uglify-js"]
+skip-missing: true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-avatar": "^1.0.4",
@@ -37,6 +38,7 @@
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.378.0",
         "next": "14.2.3",
+        "postcss": "^8",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0",
@@ -52,7 +54,8 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.9.0",
         "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-react-hooks": "^4.6.2"
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "uglify-js": "3.19.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7010,6 +7013,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
+      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
+      "dev": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,6 @@
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.378.0",
         "next": "14.2.3",
-        "postcss": "^8",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,8 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "uglify-js": "3.19.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.17.0",
@@ -56,7 +57,6 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.9.0",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "uglify-js": "3.19.2"
+    "eslint-plugin-react-hooks": "^4.6.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "lint": "next lint",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "start": "next start",
-    "start-docker": "next start -H ${FRONTEND_HOST:-localhost} -p ${FRONTEND_PORT:-3000}"
+    "start-docker": "next start -H ${FRONTEND_HOST:-localhost} -p ${FRONTEND_PORT:-3000}",
+    "postinstall": "cd ./node_modules/fabric && node build.js modules=ALL exclude=gestures"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.5",
@@ -55,6 +56,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.9.0",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2"
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "uglify-js": "3.19.2"
   }
 }

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -7,13 +7,14 @@ import HorizontalMenu from "@/components/board/HorizontalMenu";
 import useCanvas from "@/hooks/board/useCanvas";
 import useMenuData from "@/hooks/board/useMenuData";
 import useFileClick from "@/hooks/board/useFileClick";
+import { MenuAction } from "@/enums/MenuActions";
 
 const Board: React.FC = () => {
   const { canvasRef, canvas, selectedObjectStyles, handleStyleChange } =
     useCanvas();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const fileJSONInputRef = useRef<HTMLInputElement | null>(null);
-  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const [activeItem, setActiveItem] = useState<string | null>(MenuAction.SelectionMode);
 
   useFileClick(activeItem, setActiveItem, fileInputRef, fileJSONInputRef);
 

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -25,6 +25,7 @@ const Board: React.FC = () => {
     handleLoadImagesFromJson,
     color,
     size,
+    isDrawingMode,
     setColor,
     setSize,
   } = useMenuData(canvas);
@@ -51,6 +52,7 @@ const Board: React.FC = () => {
           menuGroup={addGroup}
           onIconClick={handleIconClick}
           activeItem={activeItem}
+          isDrawingMode={isDrawingMode}
           onActiveItemChange={setActiveItem}
           color={color}
           size={size}
@@ -61,6 +63,7 @@ const Board: React.FC = () => {
           menuGroup={editGroup}
           onIconClick={handleIconClick}
           activeItem={activeItem}
+          isDrawingMode={isDrawingMode}
           onActiveItemChange={setActiveItem}
           color={color}
           size={size}

--- a/frontend/src/components/board/Sidebar.tsx
+++ b/frontend/src/components/board/Sidebar.tsx
@@ -11,6 +11,7 @@ interface BoardSidebarProps {
   fromRight?: boolean;
   onActiveItemChange?: (activeItem: string | null) => void;
   activeItem: string | null;
+  isDrawingMode: boolean;
   color: string;
   size: number;
   handleColorChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -24,6 +25,7 @@ const BoardSidebar: FC<BoardSidebarProps> = ({
   fromRight = false,
   onActiveItemChange,
   activeItem,
+  isDrawingMode,
   color,
   size,
   handleColorChange,
@@ -56,6 +58,7 @@ const BoardSidebar: FC<BoardSidebarProps> = ({
               <SidebarItem
                 item={item}
                 activeItem={activeItem}
+                isDrawingMode={isDrawingMode}
                 color={color}
                 size={size}
                 handleColorChange={handleColorChange}

--- a/frontend/src/components/board/SidebarItem.tsx
+++ b/frontend/src/components/board/SidebarItem.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { MenuItem } from "../../interfaces/canva-interfaces";
+import { MenuAction } from "@/enums/MenuActions";
 
 interface SidebarItemProps {
   item: MenuItem;
   activeItem: string | null;
+  isDrawingMode: boolean,
   color: string;
   size: number;
   handleColorChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -14,6 +16,7 @@ interface SidebarItemProps {
 const SidebarItem: React.FC<SidebarItemProps> = ({
   item,
   activeItem,
+  isDrawingMode,
   color,
   size,
   handleColorChange,
@@ -25,7 +28,11 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
     <div>
       <button
         className={`flex items-center text-left text-gray-600 hover:bg-gray-200 p-2 rounded cursor-pointer ${
-          activeItem === item.name ? "bg-gray-200 text-black" : ""
+          activeItem === item.name ||
+          (item.name === MenuAction.SelectionMode && !isDrawingMode) ||
+          (item.name === MenuAction.DrawingMode && isDrawingMode)
+            ? "bg-gray-200 text-black"
+            : ""
         }`}
         onClick={() =>
           !(item.name === "change-color" || item.name === "change-size") &&

--- a/frontend/src/enums/MenuActions.ts
+++ b/frontend/src/enums/MenuActions.ts
@@ -1,5 +1,7 @@
 export enum MenuAction {
+    SelectionMode = "selection-mode",
     DrawingMode = "drawing-mode",
+    EraserMode = "eraser-mode",
     ChangeColor = "change-color",
     ChangeSize = "change-size",
     AddLine = "add-line",

--- a/frontend/src/hooks/board/useMenuData.tsx
+++ b/frontend/src/hooks/board/useMenuData.tsx
@@ -6,6 +6,7 @@ import useFileHandling from "@/hooks/board/useFileHandling";
 import useMenuActions from "@/hooks/board/useMenuActions";
 import { exportToPDF, handleSave } from "@/lib/fabricCanvasUtils";
 import { MenuGroup } from "@/interfaces/canva-interfaces";
+import { fabric } from "fabric";
 import {
   Pencil,
   MousePointer,
@@ -23,10 +24,13 @@ import {
   Redo,
   Minus,
   Undo,
+  EraserIcon,
 } from "lucide-react";
 import useKeydownListener from "./useKeydownListener";
-import {MenuAction} from "@/enums/MenuActions";
+import { MenuAction } from "@/enums/MenuActions";
+
 const useMenuData = (canvas: fabric.Canvas | null) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isDrawingMode, setIsDrawingMode } = useDrawingMode(canvas);
   const { color, size, setColor, setSize } = useColorAndSize(canvas);
   const { saveState, undo, redo } = useUndoRedo(canvas);
@@ -45,24 +49,62 @@ const useMenuData = (canvas: fabric.Canvas | null) => {
     setIsDrawingMode
   );
   useKeydownListener(canvas, performAction, undo, redo);
+
   const menuList: MenuGroup[] = [
     {
       group: "Drawing Tools",
       items: [
         {
-          action: () => setIsDrawingMode(!isDrawingMode),
-          text: isDrawingMode ? "Turn Selection Mode" : "Turn Drawing Mode",
-          icon: isDrawingMode ? <MousePointer /> : <Pencil />,
+          action: () => {
+            setIsDrawingMode(false);
+          },
+          text: "Selection Mode",
+          icon: <MousePointer />,
+          name: MenuAction.SelectionMode,
+        },
+        {
+          action: () => {
+            if (!canvas) return;
+
+            const pencilBrush = new fabric.PencilBrush(canvas);
+            pencilBrush.color = color;
+            pencilBrush.width = size;
+            pencilBrush.decimate = 4;
+
+            canvas.freeDrawingBrush = pencilBrush;
+
+            setIsDrawingMode(true);
+          },
+          text: "Drawing Mode",
+          icon: <Pencil />,
           name: MenuAction.DrawingMode,
         },
         {
-          action: () => {},
+          action: () => {
+            if (!canvas) return;
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            const eraserBrush = new fabric.EraserBrush(canvas);
+            eraserBrush.width = size;
+            eraserBrush.decimate = 4;
+            
+            canvas.freeDrawingBrush = eraserBrush;
+
+            setIsDrawingMode(true);
+          },
+          text: "Eraser Mode",
+          icon: <EraserIcon />,
+          name: MenuAction.EraserMode,
+        },
+        {
+          action: () => { },
           text: "Change Color",
           icon: <Color />,
           name: MenuAction.ChangeColor,
         },
         {
-          action: () => {},
+          action: () => { },
           text: "Change Size",
           icon: <Size />,
           name: MenuAction.ChangeSize,

--- a/frontend/src/hooks/board/useMenuData.tsx
+++ b/frontend/src/hooks/board/useMenuData.tsx
@@ -28,7 +28,7 @@ import {
 } from "lucide-react";
 import useKeydownListener from "./useKeydownListener";
 import { MenuAction } from "@/enums/MenuActions";
-import { BaseBrush } from "fabric/fabric-impl";
+import { PencilBrush } from "fabric/fabric-impl";
 
 const useMenuData = (canvas: fabric.Canvas | null) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -86,7 +86,7 @@ const useMenuData = (canvas: fabric.Canvas | null) => {
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            const eraserBrush: BaseBrush = new fabric.EraserBrush(canvas);
+            const eraserBrush: PencilBrush = new fabric.EraserBrush(canvas);
             eraserBrush.width = size;
             eraserBrush.decimate = 4;
             

--- a/frontend/src/hooks/board/useMenuData.tsx
+++ b/frontend/src/hooks/board/useMenuData.tsx
@@ -31,7 +31,6 @@ import { MenuAction } from "@/enums/MenuActions";
 import { PencilBrush } from "fabric/fabric-impl";
 
 const useMenuData = (canvas: fabric.Canvas | null) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isDrawingMode, setIsDrawingMode } = useDrawingMode(canvas);
   const { color, size, setColor, setSize } = useColorAndSize(canvas);
   const { saveState, undo, redo } = useUndoRedo(canvas);
@@ -234,6 +233,7 @@ const useMenuData = (canvas: fabric.Canvas | null) => {
     handleLoadImagesFromJson,
     color,
     size,
+    isDrawingMode,
     setColor,
     setSize,
   };

--- a/frontend/src/hooks/board/useMenuData.tsx
+++ b/frontend/src/hooks/board/useMenuData.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import useKeydownListener from "./useKeydownListener";
 import { MenuAction } from "@/enums/MenuActions";
+import { BaseBrush } from "fabric/fabric-impl";
 
 const useMenuData = (canvas: fabric.Canvas | null) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -85,7 +86,7 @@ const useMenuData = (canvas: fabric.Canvas | null) => {
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            const eraserBrush = new fabric.EraserBrush(canvas);
+            const eraserBrush: BaseBrush = new fabric.EraserBrush(canvas);
             eraserBrush.width = size;
             eraserBrush.decimate = 4;
             

--- a/frontend/src/lib/fabricCanvasUtils.ts
+++ b/frontend/src/lib/fabricCanvasUtils.ts
@@ -387,17 +387,29 @@ export const setSelectedObjectStyles = (
   canvas.requestRenderAll();
 };
 
-export const updateDimensions = (obj: any) => {
+/**
+ * This function scales the passed `fabricjs` object.
+ * It reads the values of `scaleX` and `scaleY` properties and applies them to the `width` and `height` properties
+ * by simply multiplying them accordingly. As of result the `scaleX` and `scaleY` properties are set to 1.
+ * 
+ * This function supports partialy erased objects (takes into account the `eraser` property).
+ * @param obj 
+ */
+export const updateDimensions = (obj: any): void => {
   if (!obj) {
     return;
   }
   if (obj.type === "rect" || obj.type === "circle" || obj.type === "line") {
-    const scaledWidth = Math.round(obj.width * obj.scaleX);
-    const scaledHeight = Math.round(obj.height * obj.scaleY);
+    const initialObjScaleX = obj.scaleX;
+    const initialObjScaleY = obj.scaleY;
+
+    const scaledWidth = Math.round(obj.width * initialObjScaleX);
+    const scaledHeight = Math.round(obj.height * initialObjScaleY);
     const scaledRadius = obj.radius
       ? Math.round(obj.radius * Math.max(obj.scaleX, obj.scaleY))
       : undefined;
 
+    // scale the object itself
     obj.set({
       width: scaledWidth,
       height: scaledHeight,
@@ -405,6 +417,12 @@ export const updateDimensions = (obj: any) => {
       scaleX: 1,
       scaleY: 1,
     });
+
+    // scale the erased parts
+    if (obj.eraser) {
+      obj.eraser.scaleX *= initialObjScaleX;
+      obj.eraser.scaleY *= initialObjScaleY;
+    }
   }
   obj.setCoords();
 };

--- a/frontend/src/lib/fabricCanvasUtils.ts
+++ b/frontend/src/lib/fabricCanvasUtils.ts
@@ -34,9 +34,6 @@ export const initializeCanvas = (
       selection: true,
     });
 
-    newCanvas.freeDrawingBrush.color = "black";
-    newCanvas.freeDrawingBrush.width = 5;
-    newCanvas.freeDrawingBrush.decimate = 4;
     newCanvas.on("before:render", () => (newCanvas.selection = false));
     newCanvas.on("after:render", () => (newCanvas.selection = true));
 


### PR DESCRIPTION
The eraser has been implemented thanks to a published fabricjs [eraser mixin](https://github.com/fabricjs/fabric.js/blob/master/src/mixins/eraser_brush.mixin.ts). There is the EraserBrush description:

```
  /**
   * EraserBrush class
   * Supports selective erasing meaning that only erasable objects are affected by the eraser brush.
   * Supports **inverted** erasing meaning that the brush can "undo" erasing.
   *
   * In order to support selective erasing, the brush clips the entire canvas
   * and then draws all non-erasable objects over the erased path using a pattern brush so to speak (masking).
   * If brush is **inverted** there is no need to clip canvas. The brush draws all erasable objects without their eraser.
   * This achieves the desired effect of seeming to erase or unerase only erasable objects.
   * After erasing is done the created path is added to all intersected objects' `eraser` property.
   *
   * In order to update the EraserBrush call `preparePattern`.
   * It may come in handy when canvas changes during erasing (i.e animations) and you want the eraser to reflect the changes.
   *
   * @tutorial {@link http://fabricjs.com/erasing}
   * @class fabric.EraserBrush
   * @extends fabric.PencilBrush
   * @memberof fabric
   */
```

Because the Eraser is a mixin, it isn't by default in the [npm fabric package](https://www.npmjs.com/package/fabric). That's why it has to be added into the application in the `"postinstall "` in the `package.json` file. Instruction on how to do it was found [here](https://www.npmjs.com/package/fabric-with-erasing).

Other problematic thing is the fact that the EraserBrush class is not in the `@types/fabric` package so the TS is very unhappy, because it thinks that we create and use an instance of a class that hasn't been defined anywhere. That's why we have to write `// @ts-ignore` everywhere we use it.

Edit: Scaling of erased or partialy erased object works correctly now.