### PR TITLE
feat(ws)[OK-181] Add ws error filter

### DIFF
--- a/server/src/gateway/gateway.ts
+++ b/server/src/gateway/gateway.ts
@@ -3,7 +3,6 @@ import {
   OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
-  WebSocketServer,
 } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
 import {
@@ -22,7 +21,12 @@ import {
 import { ConnectionService } from './providers/connection.service';
 import { JoinBoardService } from './providers/join.board.service';
 import { BoardPermissionGuard } from '../modules/auth/guards/board.permission.guard';
-import { UseGuards } from '@nestjs/common';
+import {
+  UseFilters,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { MinimumBoardPermission } from '../modules/auth/decorators/permissions.decorator';
 import { BoardPermission } from '../enums/board.permission';
 import { JoinSlideService } from './providers/join.slide.service';
@@ -30,14 +34,20 @@ import { SlideResponseObject } from '../shared/interfaces/response-objects/Slide
 import { SlideActionService } from './providers/slide.action.service';
 import { ObjectResponseObject } from '../shared/interfaces/response-objects/ObjectResponseObject';
 import { ObjectActionService } from './providers/object.action.service';
+import { WsExceptionFilter } from '../shared/filters/ws.error.filter';
 
 @WebSocketGateway(4003, {
   namespace: 'gateway',
 })
+@UseFilters(WsExceptionFilter)
+@UsePipes(
+  new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  }),
+)
 export class Gateway implements OnGatewayConnection, OnGatewayDisconnect {
-  @WebSocketServer()
-  server: Socket;
-
   constructor(
     private readonly connectionService: ConnectionService,
     private readonly joinBoardService: JoinBoardService,
@@ -45,8 +55,6 @@ export class Gateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly slideActionService: SlideActionService,
     private readonly objectActionService: ObjectActionService,
   ) {}
-
-  // CONNECTION
 
   async handleConnection(client: Socket): Promise<void> {
     return this.connectionService.handleConnection(client);

--- a/server/src/gateway/providers/connection.service.ts
+++ b/server/src/gateway/providers/connection.service.ts
@@ -3,6 +3,9 @@ import { WsAuthGuard } from '../../modules/auth/guards/ws.auth.guard';
 import { Socket } from 'socket.io';
 import { GwSocket } from '../../shared/interfaces/auth/GwSocket';
 
+// unfortunately, filters cannot be applied to connection handlers
+// so we have to use try-catch blocks to handle errors
+
 @Injectable()
 export class ConnectionService {
   private readonly logger = new Logger(ConnectionService.name);

--- a/server/src/gateway/providers/join.slide.service.ts
+++ b/server/src/gateway/providers/join.slide.service.ts
@@ -13,9 +13,6 @@ export class JoinSlideService {
     client: GwSocketWithTarget,
     data: JoinSlideData,
   ): Promise<SlideResponseObject> {
-    // use try-catch block to catch errors especially for get slide!!
-    // add ws error filter to catch errors
-
     const newSlideNumber = data.slide.slideNumber;
     const boardId = client.data.user.targetBoard.boardId;
     const newSlide = await this.slidesService.getSlide(boardId, newSlideNumber);

--- a/server/src/modules/boards/boards.service.ts
+++ b/server/src/modules/boards/boards.service.ts
@@ -61,7 +61,10 @@ export class BoardsService {
   ): Promise<BoardPermission> {
     const board = await this.findBoardWithPermissions(userId, boardId);
     if (!board)
-      throw new HttpException('Board not found', HttpStatus.NOT_FOUND);
+      throw new HttpException(
+        'Board not found or insufficient permissions',
+        HttpStatus.NOT_FOUND,
+      );
     return this.determineUserPermission(board, userId);
   }
 

--- a/server/src/shared/filters/http.error.filter.ts
+++ b/server/src/shared/filters/http.error.filter.ts
@@ -7,17 +7,12 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-
-interface ErrorResponse {
-  code: number;
-  path: string;
-  method: string;
-  message: string | null;
-  details?: string | object | null;
-}
+import { ErrorResponse } from '../interfaces/errors/ErrorResponse';
 
 @Catch()
 export class HttpErrorFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpErrorFilter.name);
+
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const request: Request = ctx.getRequest<Request>();
@@ -42,7 +37,7 @@ Message: ${exception.message}
 --------------------------------------------
 `;
 
-    Logger.error(logMessage, 'ExceptionFilter');
+    this.logger.error(logMessage);
 
     if (errorResponse.details === null) {
       delete errorResponse.details;

--- a/server/src/shared/filters/ws.error.filter.ts
+++ b/server/src/shared/filters/ws.error.filter.ts
@@ -1,0 +1,51 @@
+import { ArgumentsHost, Catch, HttpException, Logger } from '@nestjs/common';
+import { BaseWsExceptionFilter, WsException } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+import { ValidationError } from '../interfaces/errors/ValidationError';
+
+@Catch(WsException, HttpException)
+export class WsExceptionFilter extends BaseWsExceptionFilter {
+  private readonly logger = new Logger(WsExceptionFilter.name);
+
+  catch(exception: WsException | HttpException, host: ArgumentsHost) {
+    const client = host.switchToWs().getClient<Socket>();
+    const error = this.getError(exception);
+
+    const message = this.formatErrorMessage(error);
+    client.emit('error', { message });
+    this.logger.error(message);
+  }
+
+  private getError(exception: WsException | HttpException): ValidationError {
+    if (exception instanceof WsException) {
+      const errorResponse = exception.getError();
+      if (typeof errorResponse === 'string') {
+        return { message: errorResponse };
+      }
+      return errorResponse as ValidationError;
+    } else {
+      {
+        const errorResponse = exception.getResponse();
+        {
+          if (typeof errorResponse === 'string') {
+            return { message: errorResponse };
+          }
+          return errorResponse as ValidationError;
+        }
+      }
+    }
+  }
+
+  private formatErrorMessage(error: ValidationError): string {
+    if (typeof error.message === 'string') {
+      return this.capitalize(error.message);
+    } else if (Array.isArray(error.message)) {
+      return error.message.map(msg => this.capitalize(msg)).join(', ');
+    }
+    return 'An unknown error occurred';
+  }
+
+  private capitalize(text: string): string {
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+}

--- a/server/src/shared/interfaces/errors/ErrorResponse.ts
+++ b/server/src/shared/interfaces/errors/ErrorResponse.ts
@@ -1,0 +1,7 @@
+export interface ErrorResponse {
+  code: number;
+  path: string;
+  method: string;
+  message: string | null;
+  details?: string | object | null;
+}

--- a/server/src/shared/interfaces/errors/ValidationError.ts
+++ b/server/src/shared/interfaces/errors/ValidationError.ts
@@ -1,0 +1,3 @@
+export interface ValidationError {
+  message: string | string[];
+}


### PR DESCRIPTION
Tested different error scenarios by emitting event on `test` listener

1) Wrong dto passed - I used `ValidationPipe`
2) Instantly throwed Http Error
3) Instantly throwed Ws Error

![image](https://github.com/user-attachments/assets/c4e9cc42-2e59-4497-9133-905fb434c4aa)

Please note - filters cannot be applied to connection handlers - thats why try-catch blocks are needed for connection service