### PR TITLE
fix(ws)[OK-234] Improve joining/leaving target

### DIFF
--- a/server/src/gateway/gateway.module.ts
+++ b/server/src/gateway/gateway.module.ts
@@ -10,6 +10,7 @@ import { SlideActionService } from './providers/slide.action.service';
 import { ObjectActionService } from './providers/object.action.service';
 import { ObjectsModule } from '../modules/objects/objects.module';
 import { ResponseModule } from '../modules/response/response.module';
+import { CommonService } from './providers/common.service';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { ResponseModule } from '../modules/response/response.module';
     JoinSlideService,
     SlideActionService,
     ObjectActionService,
+    CommonService,
   ],
 })
 export class GatewayModule {}

--- a/server/src/gateway/gateway.ts
+++ b/server/src/gateway/gateway.ts
@@ -61,7 +61,7 @@ export class Gateway implements OnGatewayConnection, OnGatewayDisconnect {
     return this.connectionService.handleConnection(client);
   }
 
-  handleDisconnect(client: Socket): void {
+  handleDisconnect(client: Socket): Promise<void> {
     return this.connectionService.handleDisconnect(client);
   }
 
@@ -75,7 +75,7 @@ export class Gateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @SubscribeMessage('leave-board')
   async handleLeaveBoard(client: GwSocketWithTarget): Promise<void> {
-    return this.joinBoardService.handleLeaveBoard(client);
+    return this.joinBoardService.handleLeaveBoardAndSlide(client);
   }
 
   @MinimumBoardPermission(BoardPermission.VIEWER)
@@ -85,13 +85,6 @@ export class Gateway implements OnGatewayConnection, OnGatewayDisconnect {
     data: JoinSlideData,
   ): Promise<SlideResponseObject> {
     return this.joinSlideService.handleJoinSlide(client, data);
-  }
-
-  @UseGuards(BoardPermissionGuard)
-  @MinimumBoardPermission(BoardPermission.VIEWER)
-  @SubscribeMessage('leave-slide')
-  async handleLeaveSlide(client: GwSocketWithTarget): Promise<void> {
-    return this.joinSlideService.handleLeaveSlide(client);
   }
 
   @UseGuards(BoardPermissionGuard)

--- a/server/src/gateway/providers/common.service.ts
+++ b/server/src/gateway/providers/common.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { GwSocketWithTarget } from '../../shared/interfaces/auth/GwSocket';
+
+@Injectable()
+export class CommonService {
+  private readonly logger = new Logger(CommonService.name);
+
+  // for future use ;)
+
+  // async joinTarget(
+  //   client: GwSocketWithTarget,
+  //   ...targetTypes: ('board' | 'slide')[]
+  // ): Promise<void> {
+  //   const user = client.data.user;
+  //
+  //   for (const targetType of targetTypes) {
+  //     const targetId =
+  //       targetType === 'board'
+  //         ? user.targetBoard.boardId
+  //         : user.targetSlide.slideId;
+  //
+  //     if (!targetId) continue;
+  //     await client.join(targetId);
+  //     client.to(targetId).emit(`joined-${targetType}`, {
+  //       email: user.email,
+  //       id: user._id,
+  //     });
+  //
+  //     this.logger.log(`${user.email} has joined the ${targetType} ${targetId}`);
+  //   }
+  // }
+
+  async leaveTarget(
+    client: GwSocketWithTarget,
+    ...targetTypes: ('board' | 'slide')[]
+  ): Promise<void> {
+    const user = client.data.user;
+
+    for (const targetType of targetTypes) {
+      const targetId =
+        targetType === 'board'
+          ? user.targetBoard.boardId
+          : user.targetSlide.slideId;
+
+      if (!targetId) continue;
+      await client.leave(targetId);
+      client.to(targetId).emit(`left-${targetType}`, {
+        email: user.email,
+        _id: user._id,
+      });
+
+      this.logger.log(`${user.email} has left the ${targetType} ${targetId}`);
+    }
+  }
+}

--- a/server/src/gateway/providers/common.service.ts
+++ b/server/src/gateway/providers/common.service.ts
@@ -5,51 +5,47 @@ import { GwSocketWithTarget } from '../../shared/interfaces/auth/GwSocket';
 export class CommonService {
   private readonly logger = new Logger(CommonService.name);
 
-  // for future use ;)
-
-  // async joinTarget(
-  //   client: GwSocketWithTarget,
-  //   ...targetTypes: ('board' | 'slide')[]
-  // ): Promise<void> {
-  //   const user = client.data.user;
-  //
-  //   for (const targetType of targetTypes) {
-  //     const targetId =
-  //       targetType === 'board'
-  //         ? user.targetBoard.boardId
-  //         : user.targetSlide.slideId;
-  //
-  //     if (!targetId) continue;
-  //     await client.join(targetId);
-  //     client.to(targetId).emit(`joined-${targetType}`, {
-  //       email: user.email,
-  //       id: user._id,
-  //     });
-  //
-  //     this.logger.log(`${user.email} has joined the ${targetType} ${targetId}`);
-  //   }
-  // }
-
-  async leaveTarget(
+  async joinTarget(
     client: GwSocketWithTarget,
-    ...targetTypes: ('board' | 'slide')[]
+    targetType: 'board' | 'slide',
   ): Promise<void> {
     const user = client.data.user;
 
-    for (const targetType of targetTypes) {
-      const targetId =
-        targetType === 'board'
-          ? user.targetBoard.boardId
-          : user.targetSlide.slideId;
+    const targetId =
+      targetType === 'board'
+        ? user.targetBoard.boardId
+        : user.targetSlide?.slideId;
 
-      if (!targetId) continue;
-      await client.leave(targetId);
-      client.to(targetId).emit(`left-${targetType}`, {
-        email: user.email,
-        _id: user._id,
-      });
+    if (!targetId) return;
 
-      this.logger.log(`${user.email} has left the ${targetType} ${targetId}`);
-    }
+    await client.join(targetId);
+    client.to(targetId).emit(`joined-${targetType}`, {
+      email: user.email,
+      id: user._id,
+    });
+
+    this.logger.log(`${user.email} has joined the ${targetType} ${targetId}`);
+  }
+
+  async leaveTarget(
+    client: GwSocketWithTarget,
+    targetType: 'board' | 'slide',
+  ): Promise<void> {
+    const user = client.data.user;
+
+    const targetId =
+      targetType === 'board'
+        ? user.targetBoard.boardId
+        : user.targetSlide?.slideId;
+
+    if (!targetId) return;
+
+    await client.leave(targetId);
+    client.to(targetId).emit(`left-${targetType}`, {
+      email: user.email,
+      _id: user._id,
+    });
+
+    this.logger.log(`${user.email} has left the ${targetType} ${targetId}`);
   }
 }

--- a/server/src/gateway/providers/connection.service.ts
+++ b/server/src/gateway/providers/connection.service.ts
@@ -2,6 +2,7 @@ import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { WsAuthGuard } from '../../modules/auth/guards/ws.auth.guard';
 import { Socket } from 'socket.io';
 import { GwSocket } from '../../shared/interfaces/auth/GwSocket';
+import { JoinBoardService } from './join.board.service';
 
 // unfortunately, filters cannot be applied to connection handlers
 // so we have to use try-catch blocks to handle errors
@@ -9,7 +10,10 @@ import { GwSocket } from '../../shared/interfaces/auth/GwSocket';
 @Injectable()
 export class ConnectionService {
   private readonly logger = new Logger(ConnectionService.name);
-  constructor(private readonly wsAuthGuard: WsAuthGuard) {}
+  constructor(
+    private readonly wsAuthGuard: WsAuthGuard,
+    private readonly joinBoardService: JoinBoardService,
+  ) {}
 
   async handleConnection(client: Socket): Promise<void> {
     try {
@@ -21,7 +25,8 @@ export class ConnectionService {
     }
   }
 
-  handleDisconnect(client: Socket): void {
+  async handleDisconnect(client: Socket): Promise<void> {
+    await this.joinBoardService.handleLeaveBoardAndSlide(client);
     this.logger.log(`Client disconnected: ${client.id}`);
   }
 
@@ -39,7 +44,7 @@ export class ConnectionService {
   }
 
   private sendAuthMessage(client: Socket): void {
-    client.emit('auth', { message: 'Connection established' });
+    client.emit('auth-success', { message: 'Connection established' });
   }
 
   private logClientConnection(client: GwSocket): void {

--- a/server/src/gateway/providers/join.board.service.ts
+++ b/server/src/gateway/providers/join.board.service.ts
@@ -84,7 +84,8 @@ export class JoinBoardService {
   }
 
   async handleLeaveBoardAndSlide(client: GwSocketWithTarget): Promise<void> {
-    await this.commonService.leaveTarget(client, 'board', 'slide');
+    await this.commonService.leaveTarget(client, 'board');
+    await this.commonService.leaveTarget(client, 'slide');
   }
 
   private emitErrorAndDisconnect(client: Socket, message: string): void {

--- a/server/src/gateway/providers/join.board.service.ts
+++ b/server/src/gateway/providers/join.board.service.ts
@@ -10,11 +10,13 @@ import { BoardPermission } from '../../enums/board.permission';
 import { ResponseService } from '../../modules/response/response.service';
 import { BoardResponseObject } from '../../shared/interfaces/response-objects/BoardResponseObject';
 import { WsException } from '@nestjs/websockets';
+import { CommonService } from './common.service';
 
 @Injectable()
 export class JoinBoardService {
   constructor(
     private readonly boardsService: BoardsService,
+    private readonly commonService: CommonService,
     private readonly res: ResponseService,
   ) {}
   private readonly logger = new Logger(JoinBoardService.name);
@@ -75,29 +77,14 @@ export class JoinBoardService {
     const user = client.data.user;
     await client.join(boardId);
     client.to(boardId).emit('joined-board', {
-      message: `${user.email} has joined the board`,
+      email: user.email,
+      _id: user._id,
     });
     this.logger.log(`${user.email} has joined the board ${boardId}`);
   }
 
-  async handleLeaveBoard(client: GwSocketWithTarget): Promise<void> {
-    const user = client.data.user;
-    const boardId = user.targetBoard.boardId;
-    const slideId = user.targetSlide.slideId;
-
-    if (slideId) {
-      await client.leave(slideId);
-      client.to(slideId).emit('left-slide', {
-        message: `${user.email} has left the slide`,
-      });
-      this.logger.log(`${user.email} has left the slide`);
-    }
-
-    await client.leave(boardId);
-    client.to(boardId).emit('left-board', {
-      message: `${user.email} has left the board`,
-    });
-    this.logger.log(`${user.email} has left the board`);
+  async handleLeaveBoardAndSlide(client: GwSocketWithTarget): Promise<void> {
+    await this.commonService.leaveTarget(client, 'board', 'slide');
   }
 
   private emitErrorAndDisconnect(client: Socket, message: string): void {

--- a/server/src/gateway/providers/join.slide.service.ts
+++ b/server/src/gateway/providers/join.slide.service.ts
@@ -3,10 +3,14 @@ import { GwSocketWithTarget } from '../../shared/interfaces/auth/GwSocket';
 import { JoinSlideData } from '../gateway.dto';
 import { SlidesService } from '../../modules/slides/slides.service';
 import { SlideResponseObject } from '../../shared/interfaces/response-objects/SlideResponseObject';
+import { CommonService } from './common.service';
 
 @Injectable()
 export class JoinSlideService {
-  constructor(private readonly slidesService: SlidesService) {}
+  constructor(
+    private readonly slidesService: SlidesService,
+    private readonly commonService: CommonService,
+  ) {}
   private readonly logger = new Logger(JoinSlideService.name);
 
   async handleJoinSlide(
@@ -35,23 +39,13 @@ export class JoinSlideService {
     const user = client.data.user;
     await client.join(slideId);
     client.to(slideId).emit('joined-slide', {
-      message: `${user.email} has joined the slide`,
+      email: user.email,
+      _id: user._id,
     });
     this.logger.log(`${user.email} has joined the slide ${slideId}`);
   }
 
   async leaveCurrentSlide(client: GwSocketWithTarget): Promise<void> {
-    const user = client.data.user;
-    const slideId = user.targetSlide.slideId;
-    if (!slideId) return;
-    await client.leave(slideId);
-    client.to(slideId).emit('left-slide', {
-      message: `${user.email} has left the slide`,
-    });
-    this.logger.log(`${user.email} has left the slide ${slideId}`);
-  }
-
-  async handleLeaveSlide(client: GwSocketWithTarget): Promise<void> {
-    await this.leaveCurrentSlide(client);
+    return this.commonService.leaveTarget(client, 'slide');
   }
 }


### PR DESCRIPTION
1) _auth-success_ is emitted instead of _auth_ when user is succesfully authenticated
2) Client info is emitted when client joined/left board/slide (email + _id) - **not a message**!
3) Client cannot leave slide - its attached once they joined
4) When client's connection is terminated, they leave board & slide at once (info is emitted)
5) Reminder: when a client leaves a board, a board, leaves a slide too