### PR TITLE
fix(board)[OK-278] Fix bugs related to join/leave board

### DIFF
--- a/client/src/components/board/HorizontalMenu.tsx
+++ b/client/src/components/board/HorizontalMenu.tsx
@@ -68,7 +68,7 @@ const BoardHorizontalMenu: FC<HorizontalMenuProps> = ({ groupId }) => {
         </div>
       </div>
       <div className="flex h-[64px] items-center space-x-4 border-l pl-4 pr-2">
-        <UserInfo />
+        <UserInfo withoutLogout={true} />
       </div>
     </div>
   );

--- a/client/src/components/error/BoardError.tsx
+++ b/client/src/components/error/BoardError.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+export const BoardError = () => {
+  const router = useRouter();
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-6">
+      <h1 className="text-4xl font-bold text-error-foreground">Connection error</h1>
+      <p className="text-error-foreground">We encountered an error while trying to connect to the board</p>
+      <div className={"flex gap-4"}>
+        <Button onClick={() => window.location.reload()} variant="secondary" className={"w-48"}>
+          Refresh the page
+        </Button>
+        <Button className={"w-48"} onClick={() => router.push("/user-boards")}>
+          Return to your boards
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/main-header/UserInfo.tsx
+++ b/client/src/components/main-header/UserInfo.tsx
@@ -1,11 +1,10 @@
 "use client";
-import { FC } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import ThemeToggle from "./ThemeToggle";
 import LogoutButton from "@/components/main-header/LougoutButton";
 import { useAuth } from "@/contexts/AuthContext";
 
-const UserInfo: FC = ({ withoutLogout }: { withoutLogout?: boolean }) => {
+const UserInfo = ({ withoutLogout }: { withoutLogout?: boolean }) => {
   const { decodedToken } = useAuth();
   return (
     <>

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -8,6 +8,7 @@ import { socketEmitJoinBoard } from "@/lib/board/socketEmitUtils";
 import { BasicUserInfo, JoinBoardResponse, SimpleMessage } from "@/interfaces/socket/SocketCallbacksData";
 import logger from "@/lib/logger";
 import { getSocket } from "@/services/socketService";
+import { BoardError } from "@/components/error/BoardError";
 
 interface SocketContextProps {
   totalSlides: number;
@@ -32,11 +33,6 @@ interface SocketProviderProps {
 export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardId }) => {
   const token = `Bearer ${Cookies.get("accessToken")}`;
   const socketRef = useRef<Socket | null>(null);
-
-  if (!socketRef.current) {
-    socketRef.current = getSocket();
-  }
-
   const [isSocketReady, setIsSocketReady] = useState(false);
   const [totalSlides, setTotalSlides] = useState<number>(100);
   const [boardName, setBoardName] = useState<string | undefined>(undefined);
@@ -44,7 +40,12 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
   const [boardOwner, setBoardOwner] = useState<string | undefined>(undefined);
   const [isBoardJoined, setIsBoardJoined] = useState(false);
   const [firstSlideChanged, setFirstSlideChanged] = useState(false);
+  const [connectionError, setConnectionError] = useState(false);
   useEffect(() => {
+    if (!socketRef.current) {
+      socketRef.current = getSocket(socketRef.current);
+    }
+
     const socket = socketRef.current;
     if (!socket) {
       return;
@@ -56,7 +57,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
       setCurrentPermission(res.permission);
       setBoardOwner(res.owner);
       setIsBoardJoined(true);
-
+      setConnectionError(false);
       setIsSocketReady(true);
       toast.success("Joined board " + boardId);
     }
@@ -83,6 +84,17 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
       joinBoard();
     }
 
+    function onConnectError() {
+      toast.error("Connection error");
+      logger.log("Connection error");
+      setConnectionError(true);
+    }
+
+    function onReconnectAttempt() {
+      toast.info("Reconnecting...");
+      logger.log("Reconnecting...");
+    }
+
     function joinBoard() {
       if (!socket || !boardId) {
         toast.error("No socket");
@@ -99,6 +111,8 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
       { eventName: "joined-slide", handler: onUserJoinedSlide },
       { eventName: "left-slide", handler: onUserLeftSlide },
       { eventName: "auth-success", handler: onAuthSuccess },
+      { eventName: "connect_error", handler: onConnectError },
+      { eventName: "reconnect_attempt", handler: onReconnectAttempt },
     ];
 
     handlers.forEach(({ eventName, handler }) => {
@@ -115,10 +129,14 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
         socket.off(eventName, handler);
       });
 
-      //socketEmitLeaveBoard(socket, {});
-      //socketRef?.current?.disconnect();
+      socketRef?.current?.disconnect();
+      socketRef.current = null;
     };
   }, [token, boardId]);
+
+  if (connectionError) {
+    return <BoardError />;
+  }
 
   if (!isSocketReady) {
     return <SocketLoading />;

--- a/client/src/contexts/SocketContext.tsx
+++ b/client/src/contexts/SocketContext.tsx
@@ -85,12 +85,14 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children, boardI
     }
 
     function onConnectError() {
+      toast.dismiss();
       toast.error("Connection error");
-      logger.log("Connection error");
+      logger.error("Connection error");
       setConnectionError(true);
     }
 
     function onReconnectAttempt() {
+      toast.dismiss();
       toast.info("Reconnecting...");
       logger.log("Reconnecting...");
     }

--- a/client/src/services/socketService.ts
+++ b/client/src/services/socketService.ts
@@ -6,9 +6,7 @@ const SOCKET_GW_PORT = process.env.SOCKET_GW_PORT;
 
 const baseUrl = `http://${API_HOST}:${SOCKET_GW_PORT}`;
 
-let socket: Socket | null = null;
-
-export function getSocket(): Socket {
+export function getSocket(socket: Socket | null): Socket {
   if (!socket) {
     const token = `Bearer ${Cookies.get("accessToken")}`;
     socket = io(`${baseUrl}/gateway`, {


### PR DESCRIPTION
1. When the user attempted to leave the board by clicking the logo, the connection remained active.

2. When the user tried to revisit the board, the socket from the previous render was retained using useRef

Actions to take:
- Please go to the board (ideally in the first and second browser tabs), click the logo, or the previous page button from the browser, and check if you receive any information about leaving the board in another tab. Then try to return to the same board.
- Next, disconnect the backend and attempt to access the board again.


