### PR TITLE
fix(Cursors)[OK-302] Fix bug with cursors position while zoom

### DIFF
--- a/client/src/components/board/cursors/Cursor.tsx
+++ b/client/src/components/board/cursors/Cursor.tsx
@@ -10,25 +10,21 @@ interface CursorProps {
   canvas: fabric.Canvas | null;
 }
 
-const Cursor: React.FC<CursorProps> = ({ cursor, canvas }) => {
+export const Cursor: React.FC<CursorProps> = ({ cursor, canvas }) => {
   const color = useMemo(() => getColorFromEmail(cursor.user.email), [cursor.user.email]);
 
   const cursorColor = useMemo(() => darkerColor(color, 20), [color]);
 
-  const { clampedX, clampedY } = useMemo(() => {
-    if (!canvas) {
-      return { clampedX: 0, clampedY: 0 };
-    }
+  if (!canvas) {
+    return null;
+  }
 
-    const transform = canvas.viewportTransform;
-    const point = new fabric.Point(cursor.cursorData.x, cursor.cursorData.y);
-    const transformedPoint = fabric.util.transformPoint(point, transform as number[]);
+  const transform = canvas.viewportTransform;
+  const point = new fabric.Point(cursor.cursorData.x, cursor.cursorData.y);
+  const transformedPoint = fabric.util.transformPoint(point, transform as number[]);
 
-    const clampedX = Math.min(Math.max(transformedPoint.x, 0), canvas.getWidth());
-    const clampedY = Math.min(Math.max(transformedPoint.y, 0), canvas.getHeight());
-
-    return { clampedX, clampedY };
-  }, [canvas, cursor.cursorData.x, cursor.cursorData.y]);
+  const clampedX = Math.min(Math.max(transformedPoint.x, 0), canvas.getWidth());
+  const clampedY = Math.min(Math.max(transformedPoint.y, 0), canvas.getHeight());
 
   return (
     <motion.div
@@ -49,5 +45,3 @@ const Cursor: React.FC<CursorProps> = ({ cursor, canvas }) => {
     </motion.div>
   );
 };
-
-export default React.memo(Cursor);

--- a/client/src/components/board/cursors/Cursors.tsx
+++ b/client/src/components/board/cursors/Cursors.tsx
@@ -5,7 +5,7 @@ import logger from "@/lib/logger";
 import { CursorPosition } from "@/interfaces/responses/cursor/cursor-position-emit";
 import { BasicUserInfo } from "@/interfaces/socket/SocketCallbacksData";
 import { useCanvas } from "@/contexts/CanvasContext";
-import Cursor from "./Cursor";
+import { Cursor } from "./Cursor";
 import { getColorFromEmail } from "@/lib/colorUtils";
 
 interface CursorsProps {


### PR DESCRIPTION
When the cursors were not moving and I started zooming, their positions did not change. Previously, it worked perfectly. This bug was caused by memoizing the Cursor component. Now, it should work fine.