### PR TITLE
feat(modify-permission)[OK-319] Integrate action of updating and deleting permissions with frontend

### DIFF
--- a/client/src/app/actions/permissionsActions.ts
+++ b/client/src/app/actions/permissionsActions.ts
@@ -8,6 +8,7 @@ import { boardPermissionToNum } from "@/lib/permissionUtils";
 import { GrantPermissionResponse } from "@/interfaces/responses/board-permission/grant-permission-response";
 import { apiRequest } from "@/services/requestService";
 import { BoardPermissionModifyRequest } from "@/interfaces/requests/board-permission-modify-request";
+import { revalidatePath } from "next/cache";
 
 export async function generatePermissionCode(
   boardId: string,
@@ -67,6 +68,7 @@ export async function modifyPermission(
       },
       body: JSON.stringify(boardPermissionModifyRequest),
     });
+    revalidatePath(`/boards/${boardId}/permissions`);
   } catch (error) {
     logger.error("Error while modifying permission:", error);
     throw error;

--- a/client/src/app/actions/permissionsActions.ts
+++ b/client/src/app/actions/permissionsActions.ts
@@ -7,6 +7,7 @@ import { BoardPermission } from "@/enums/BoardPermission";
 import { boardPermissionToNum } from "@/lib/permissionUtils";
 import { GrantPermissionResponse } from "@/interfaces/responses/board-permission/grant-permission-response";
 import { apiRequest } from "@/services/requestService";
+import { BoardPermissionModifyRequest } from "@/interfaces/requests/board-permission-modify-request";
 
 export async function generatePermissionCode(
   boardId: string,
@@ -47,6 +48,27 @@ export async function grantPermission(code: string): Promise<GrantPermissionResp
     return await response.json();
   } catch (error) {
     logger.error("Error while granting permission:", error);
+    throw error;
+  }
+}
+
+export async function modifyPermission(
+  boardId: string,
+  boardPermissionModifyRequest: BoardPermissionModifyRequest
+): Promise<void> {
+  logger.log(`Modifying permission for user ${boardPermissionModifyRequest.userId} on board ${boardId}`);
+  const token = getCookie("accessToken");
+  try {
+    await apiRequest(`/boards/${boardId}/permissions/modify`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(boardPermissionModifyRequest),
+    });
+  } catch (error) {
+    logger.error("Error while modifying permission:", error);
     throw error;
   }
 }

--- a/client/src/components/board-details/board-permissions/BoardPermissions.tsx
+++ b/client/src/components/board-details/board-permissions/BoardPermissions.tsx
@@ -66,7 +66,7 @@ export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => 
       userId: user.id,
       permission: boardPermissionToNum(newPermission),
     };
-    await modifyPermission(board._id, boardPermissionModifyRequest);
+    await modifyPermission(board._id, boardPermissionModifyRequest); //note: I don't want to throw an error here, it should be handled in the BoardPermissionsSelect component
   };
 
   return (
@@ -123,13 +123,8 @@ export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => 
               </TableCell>
 
               <TableCell className="flex items-center justify-center">
-                {capabilityFunctions.canManageUsersPermissions(board.permission) && (
-                  <DeleteCollaboratorButton
-                    username={user.name}
-                    deleteUser={() => {
-                      /* Implement collaborator deletion */
-                    }}
-                  />
+                {capabilityFunctions.canManageUsersPermissions(board.permission) && user.id !== decodedToken?._id && (
+                  <DeleteCollaboratorButton user={user} boardId={board._id} />
                 )}
               </TableCell>
             </TableRow>

--- a/client/src/components/board-details/board-permissions/BoardPermissions.tsx
+++ b/client/src/components/board-details/board-permissions/BoardPermissions.tsx
@@ -80,7 +80,7 @@ export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => 
             <span className="text-muted-foreground">Board owner:</span>
             <Avatar>
               <AvatarFallback>{board.owner.email.slice(0, 2).toUpperCase()}</AvatarFallback>
-              <AvatarImage src="https://via.placeholder.com/150" alt={board.owner.email} />
+              <AvatarImage src="#" alt={board.owner.email} />
             </Avatar>
             <span className="font-bold text-foreground">{board.owner.email}</span>
           </div>

--- a/client/src/components/board-details/board-permissions/BoardPermissions.tsx
+++ b/client/src/components/board-details/board-permissions/BoardPermissions.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BoardPermissionsUser } from "@/interfaces/board-permissions-user";
-import React, { useCallback, useMemo, useState } from "react";
+import React from "react";
 import { BoardPermission } from "@/enums/BoardPermission";
 import { BoardHeader } from "@/components/user-boards/BoardHeader";
 import BoardPermissionsInfoDialog from "@/components/board-details/board-permissions/BoardPermissionsInfoDialog";
@@ -12,50 +12,62 @@ import BoardPermissionsSelect from "@/components/board-details/board-permissions
 import { BoardTableLeadRow } from "@/components/user-boards/board-table/BoardTableLeadRow";
 import DeleteCollaboratorButton from "@/components/board-details/board-permissions/DeleteCollaboratorButton";
 import { BoardDetailsResponse } from "@/interfaces/responses/board-details-response";
-import logger from "@/lib/logger";
 import ShareBoardDialog from "@/components/board-details/board-permissions/ShareBoardDialog";
-import { capabilityFunctions } from "@/lib/permissionUtils";
+import { boardPermissionToNum, capabilityFunctions } from "@/lib/permissionUtils";
 import { Badge } from "@/components/ui/badge";
 import { getPermissionLabel, getPermissionVariant } from "@/lib/userBoardsUtils";
+import { modifyPermission } from "@/app/actions/permissionsActions";
+import { BoardPermissionModifyRequest } from "@/interfaces/requests/board-permission-modify-request";
+import logger from "@/lib/logger";
+import { useAuth } from "@/contexts/AuthContext";
+
 export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => {
-  const mapPermissions = useCallback((board: BoardDetailsResponse): BoardPermissionsUser[] => {
-    const { viewer: viewers, editor: editors, moderator: moderators } = board.permissions;
-    const users: BoardPermissionsUser[] = [];
+  const { decodedToken } = useAuth();
+  const users: BoardPermissionsUser[] = React.useMemo(() => {
+    const mapPermissionsAndSortUsers = (board: BoardDetailsResponse): BoardPermissionsUser[] => {
+      const { viewer: viewers, editor: editors, moderator: moderators } = board.permissions;
+      const users: BoardPermissionsUser[] = [];
 
-    viewers.forEach((user) => {
-      users.push({
-        name: user.email, // Using email as name for display
-        permission: BoardPermission.VIEWER,
+      viewers.forEach((user) => {
+        users.push({
+          name: user.email,
+          permission: BoardPermission.VIEWER,
+          id: user._id,
+        });
       });
-    });
 
-    editors.forEach((user) => {
-      users.push({
-        name: user.email,
-        permission: BoardPermission.EDITOR,
+      editors.forEach((user) => {
+        users.push({
+          name: user.email,
+          permission: BoardPermission.EDITOR,
+          id: user._id,
+        });
       });
-    });
 
-    moderators.forEach((user) => {
-      users.push({
-        name: user.email,
-        permission: BoardPermission.MODERATOR,
+      moderators.forEach((user) => {
+        users.push({
+          name: user.email,
+          permission: BoardPermission.MODERATOR,
+          id: user._id,
+        });
       });
-    });
 
-    return users;
-  }, []);
+      users.sort((a, b) => a.name.localeCompare(b.name));
+      return users;
+    };
 
-  const [users] = useState<BoardPermissionsUser[]>(mapPermissions(board));
+    return mapPermissionsAndSortUsers(board);
+  }, [board]);
 
-  const handlePermissionChange = (index: number, newPermission: BoardPermission) => {
-    logger.log(`User ${users[index].name} permission changed to ${newPermission}`);
-    /*todo: implement this method*/
+  const handlePermissionChange = async (index: number, newPermission: BoardPermission) => {
+    const user = users[index];
+    logger.log(`Changing permission for user:${users[index].name} to ${newPermission}`);
+    const boardPermissionModifyRequest: BoardPermissionModifyRequest = {
+      userId: user.id,
+      permission: boardPermissionToNum(newPermission),
+    };
+    await modifyPermission(board._id, boardPermissionModifyRequest);
   };
-
-  const sortedUsers = useMemo(() => {
-    return [...users].sort((a, b) => a.name.localeCompare(b.name));
-  }, [users]);
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 shadow">
@@ -86,22 +98,24 @@ export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => 
       <Table>
         <BoardTableLeadRow columns={["User", "Permission"]} />
         <TableBody>
-          {sortedUsers.map((user, index) => (
-            <TableRow key={user.name} className="border-b border-border hover:bg-muted/50">
+          {users.map((user, index) => (
+            <TableRow key={user.id} className="border-b border-border hover:bg-muted/50">
               <TableCell>
                 <div className="flex items-center space-x-2">
                   <Avatar>
                     <AvatarFallback>{user.name.slice(0, 2).toUpperCase()}</AvatarFallback>
-                    <AvatarImage src="https://via.placeholder.com/150" alt={user.name} />
+                    <AvatarImage src="#" alt={user.name} />
                   </Avatar>
                   <span className="text-foreground">{user.name}</span>
                 </div>
               </TableCell>
               <TableCell>
-                {capabilityFunctions.canManageUsersPermissions(board.permission) ? (
+                {capabilityFunctions.canManageUsersPermissions(board.permission) && user.id !== decodedToken?._id ? (
                   <BoardPermissionsSelect
                     boardMemberPermission={user.permission}
-                    onChange={(newPermission) => handlePermissionChange(index, newPermission)}
+                    onSendRequest={async (newPermission) => {
+                      await handlePermissionChange(index, newPermission);
+                    }}
                   />
                 ) : (
                   <Badge variant={getPermissionVariant(user.permission)}>{getPermissionLabel(user.permission)}</Badge>
@@ -113,7 +127,7 @@ export const BoardPermissions = ({ board }: { board: BoardDetailsResponse }) => 
                   <DeleteCollaboratorButton
                     username={user.name}
                     deleteUser={() => {
-                      /*todo: implement collaborator deletion*/
+                      /* Implement collaborator deletion */
                     }}
                   />
                 )}

--- a/client/src/components/board-details/board-permissions/BoardPermissionsSelect.tsx
+++ b/client/src/components/board-details/board-permissions/BoardPermissionsSelect.tsx
@@ -1,23 +1,55 @@
+"use client";
 import React from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { BoardPermission } from "@/enums/BoardPermission";
 import { getPermissionLabel, getPermissionVariant } from "@/lib/userBoardsUtils";
+import logger from "@/lib/logger";
+import { toast } from "sonner";
+
 interface PermissionSelectProps {
   boardMemberPermission: BoardPermission;
-  onChange: (newPermission: BoardPermission) => void;
+  onSendRequest?: (newPermission: BoardPermission) => Promise<void> | void;
   className?: string;
 }
-const BoardPermissionsSelect: React.FC<PermissionSelectProps> = ({ boardMemberPermission, className, onChange }) => {
+
+const BoardPermissionsSelect: React.FC<PermissionSelectProps> = ({
+  boardMemberPermission,
+  className,
+  onSendRequest,
+}) => {
   const permissions: BoardPermission[] = [BoardPermission.VIEWER, BoardPermission.EDITOR, BoardPermission.MODERATOR];
+
+  const [selectedPermission, setSelectedPermission] = React.useState<BoardPermission>(boardMemberPermission);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+
+  const handleChange = async (newPermission: BoardPermission) => {
+    if (!onSendRequest) {
+      setSelectedPermission(newPermission);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await onSendRequest(newPermission);
+      setSelectedPermission(newPermission);
+    } catch (error) {
+      logger.error(`Failed to change permission`, error);
+      toast.error(`Failed to update permission`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
-    <Select onValueChange={(value) => onChange(value as BoardPermission)}>
+    <Select
+      value={selectedPermission}
+      onValueChange={(value) => handleChange(value as BoardPermission)}
+      disabled={isLoading}
+    >
       <SelectTrigger className={"flex cursor-pointer justify-around " + className}>
         <SelectValue
           placeholder={
-            <Badge variant={getPermissionVariant(boardMemberPermission)}>
-              {getPermissionLabel(boardMemberPermission)}
-            </Badge>
+            <Badge variant={getPermissionVariant(selectedPermission)}>{getPermissionLabel(selectedPermission)}</Badge>
           }
         />
       </SelectTrigger>
@@ -26,7 +58,7 @@ const BoardPermissionsSelect: React.FC<PermissionSelectProps> = ({ boardMemberPe
           <SelectItem
             key={permission}
             value={permission}
-            disabled={permission === boardMemberPermission}
+            disabled={permission === selectedPermission}
             className="flex cursor-pointer items-center justify-center"
           >
             <Badge variant={getPermissionVariant(permission)}>{getPermissionLabel(permission)}</Badge>
@@ -36,4 +68,5 @@ const BoardPermissionsSelect: React.FC<PermissionSelectProps> = ({ boardMemberPe
     </Select>
   );
 };
+
 export default BoardPermissionsSelect;

--- a/client/src/components/board-details/board-permissions/BoardPermissionsSelect.tsx
+++ b/client/src/components/board-details/board-permissions/BoardPermissionsSelect.tsx
@@ -6,6 +6,9 @@ import { BoardPermission } from "@/enums/BoardPermission";
 import { getPermissionLabel, getPermissionVariant } from "@/lib/userBoardsUtils";
 import logger from "@/lib/logger";
 import { toast } from "sonner";
+import { ApiError } from "@/errors/ApiError";
+import { complexToast } from "@/contexts/complexToast";
+import { ToastTypes } from "@/enums/ToastType";
 
 interface PermissionSelectProps {
   boardMemberPermission: BoardPermission;
@@ -32,9 +35,13 @@ const BoardPermissionsSelect: React.FC<PermissionSelectProps> = ({
     try {
       await onSendRequest(newPermission);
       setSelectedPermission(newPermission);
-    } catch (error) {
+    } catch (error: any) {
       logger.error(`Failed to change permission`, error);
-      toast.error(`Failed to update permission`);
+      if (error instanceof ApiError) {
+        complexToast(ToastTypes.ERROR, error.messages, { duration: Infinity });
+      } else {
+        toast.error(error.message || "Failed to update permission");
+      }
     } finally {
       setIsLoading(false);
     }

--- a/client/src/components/board-details/board-permissions/DeleteCollaboratorButton.tsx
+++ b/client/src/components/board-details/board-permissions/DeleteCollaboratorButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,15 +11,25 @@ import {
 } from "@/components/ui/dialog";
 import { TrashIcon } from "lucide-react";
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
+import { BoardPermissionsUser } from "@/interfaces/board-permissions-user";
+import { toast } from "sonner";
+import logger from "@/lib/logger";
+import { ApiError } from "@/errors/ApiError";
+import { complexToast } from "@/contexts/complexToast";
+import { ToastTypes } from "@/enums/ToastType";
+import { BoardPermissionModifyRequest } from "@/interfaces/requests/board-permission-modify-request";
+import { modifyPermission } from "@/app/actions/permissionsActions";
+import { BoardPermissionNum } from "@/enums/BoardPermissionNum";
 
 interface DeleteCollaboratorButtonProps {
-  deleteUser: (username: string) => void;
-  username: string;
+  user: BoardPermissionsUser;
+  boardId: string;
 }
 
-const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ deleteUser, username }) => {
-  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
+const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ user, boardId }) => {
   const triggerButtonRef = React.useRef<HTMLButtonElement>(null);
+  const [isPending, startTransition] = useTransition();
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
   const handleDialogOpenChange = (open: boolean) => {
     setIsDialogOpen(open);
@@ -27,13 +37,29 @@ const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ del
       triggerButtonRef.current.blur();
     }
   };
-
   const handleButtonClick = () => {
     setIsDialogOpen(true);
   };
 
   const handleDeleteUser = () => {
-    deleteUser(username);
+    startTransition(async () => {
+      try {
+        const boardPermissionModifyRequest: BoardPermissionModifyRequest = {
+          userId: user.id,
+          permission: BoardPermissionNum.NONE,
+        };
+        await modifyPermission(boardId, boardPermissionModifyRequest);
+        toast.success("Collaborator deleted successfully");
+      } catch (error: any) {
+        logger.error("Error in handleDeleteUser:", error);
+        if (error instanceof ApiError) {
+          complexToast(ToastTypes.ERROR, error.messages, { duration: Infinity });
+        } else {
+          toast.error(error.message || "Failed to delete board");
+        }
+      }
+    });
+    handleDialogOpenChange(false);
   };
 
   return (
@@ -42,7 +68,7 @@ const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ del
         <Button
           variant="outline"
           className="hover:text-muted-foreground"
-          aria-label={`Delete collaborator ${username}`}
+          aria-label={`Delete collaborator ${user.name}`}
           onClick={handleButtonClick}
           ref={triggerButtonRef}
         >
@@ -57,7 +83,7 @@ const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ del
           <DialogHeader>
             <DialogTitle>Delete Collaborator</DialogTitle>
             <DialogDescription>
-              Are you sure you want to remove collaborator <strong>{username}</strong> from this board?
+              Are you sure you want to remove collaborator <strong>{user.name}</strong> from this board?
               <br />
               This action is <strong>irreversible!</strong>
             </DialogDescription>
@@ -66,11 +92,9 @@ const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ del
             <DialogClose asChild>
               <Button variant="secondary">Cancel</Button>
             </DialogClose>
-            <DialogClose asChild>
-              <Button variant="destructive" onClick={handleDeleteUser} className="ml-2">
-                Delete
-              </Button>
-            </DialogClose>
+            <Button disabled={isPending} variant="destructive" onClick={handleDeleteUser} className="ml-2">
+              Delete
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/client/src/components/board-details/board-permissions/DeleteCollaboratorButton.tsx
+++ b/client/src/components/board-details/board-permissions/DeleteCollaboratorButton.tsx
@@ -84,8 +84,6 @@ const DeleteCollaboratorButton: React.FC<DeleteCollaboratorButtonProps> = ({ use
             <DialogTitle>Delete Collaborator</DialogTitle>
             <DialogDescription>
               Are you sure you want to remove collaborator <strong>{user.name}</strong> from this board?
-              <br />
-              This action is <strong>irreversible!</strong>
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex justify-between">

--- a/client/src/components/board-details/board-permissions/ShareBoardDialog.tsx
+++ b/client/src/components/board-details/board-permissions/ShareBoardDialog.tsx
@@ -85,7 +85,7 @@ const ShareBoardDialog: React.FC<ShareBoardDialogProps> = ({ boardId, children }
               <BoardPermissionsSelect
                 boardMemberPermission={permission}
                 className="w-48"
-                onChange={(newPermission) => setPermission(newPermission)}
+                onSendRequest={(newPermission) => setPermission(newPermission)}
               />
             </div>
             <Button onClick={generateLink} disabled={isPending} className="w-full">

--- a/client/src/interfaces/board-permissions-user.ts
+++ b/client/src/interfaces/board-permissions-user.ts
@@ -3,4 +3,5 @@ import { BoardPermission } from "@/enums/BoardPermission";
 export interface BoardPermissionsUser {
   name: string;
   permission: BoardPermission;
+  id: string;
 }

--- a/client/src/interfaces/requests/board-permission-modify-request.ts
+++ b/client/src/interfaces/requests/board-permission-modify-request.ts
@@ -1,0 +1,4 @@
+export interface BoardPermissionModifyRequest {
+  userId: string;
+  permission: number;
+}


### PR DESCRIPTION
I initially thought this would be easy, but it turned out to be more complicated. The Select component from shadcn/ui behaves in such a way that it always changes its displayed value immediately upon clicking an option. I wanted to create a behavior where, if the backend request fails, the value in the Select field doesn't change. Therefore, I needed to modify the BoardPermissionsSelect component to control when the value updates based on the success of the backend request.